### PR TITLE
ContinueRetrievePropertiesEx returns broken RetrieveResult

### DIFF
--- a/pyvisdk/base/base_entity.py
+++ b/pyvisdk/base/base_entity.py
@@ -43,7 +43,7 @@ class TaskDelegate(object):
         if self.name[-5:] == '_Task' and self.cls.core.wait_for_task:
             log.debug("Waiting for task to Complete")
             self.cls.core.waitForTask(rv)
-        if self.__target.method.name in ["RetrieveProperties", "RetrievePropertiesEx"]:
+        if self.__target.method.name in ["RetrieveProperties", "RetrievePropertiesEx", "ContinueRetrievePropertiesEx"]:
             return rv
         else:
             return self.cls.core._parse_object_content(rv)


### PR DESCRIPTION
Hi,

instead of ObjectContent objects in RetrieveResult's objects-attribute, you get mere lists of values. RetrievePropertiesEx works fine, though. The reason is the special treatment of RetrieveProperties and RetrievePropertiesEx in the TaskDelegate class. Adding ContinueRetrievePropertiesEx to the special treatment, the returned objects are fine.

Regards,
Manuel Hermann
